### PR TITLE
added missing translation placeholder text other languages

### DIFF
--- a/i18n/ar.yml
+++ b/i18n/ar.yml
@@ -28,3 +28,6 @@ start: |
 
   إستعمل /help لمعومات إضافية.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/ar.yml
+++ b/i18n/ar.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/de.yml
+++ b/i18n/de.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/de.yml
+++ b/i18n/de.yml
@@ -28,3 +28,6 @@ start: |
 
   Nutze /help für mehr Info.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/fa.yml
+++ b/i18n/fa.yml
@@ -28,3 +28,6 @@ start: |
 
   Use /help for more info.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/fa.yml
+++ b/i18n/fa.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -28,3 +28,6 @@ start: |
 
   Use /help for more info.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/it.yml
+++ b/i18n/it.yml
@@ -28,3 +28,6 @@ start: |
 
   Usa /help per maggiori informazioni.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/it.yml
+++ b/i18n/it.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/ja.yml
+++ b/i18n/ja.yml
@@ -28,3 +28,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 14, 15, 17, 19, 20, 21, 22, 24, 26, 27, 28, 29, 30 require translating. This line can be deleted once translations have happened.

--- a/i18n/ja.yml
+++ b/i18n/ja.yml
@@ -25,3 +25,6 @@ start: |
 
   Use /help for more info.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/nl.yml
+++ b/i18n/nl.yml
@@ -28,3 +28,6 @@ start: |
 
   Gebruik /help voor meer info.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty

--- a/i18n/nl.yml
+++ b/i18n/nl.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -31,3 +31,5 @@ last_couples: Last chosen couples
 top_lovers: Top lovers
 empty_lovers_list: Lovers top is empty
 empty_last_list: Last chosen couples list is empty
+
+# lines 24, 30, 31, 32, 33 require translating. This line can be deleted once translations have happened.

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -28,3 +28,6 @@ start: |
 
   Use /help para mais informações.
 last_couples: Last chosen couples
+top_lovers: Top lovers
+empty_lovers_list: Lovers top is empty
+empty_last_list: Last chosen couples list is empty


### PR DESCRIPTION
The placeholder text for missing translation pieces were added to the bottom of the language files that didn't contain them.

Comments were added to the bottom of the file for users to find the lines that still require translating.

This makes it easier on new users to know what to translate